### PR TITLE
Remove markdown from package init

### DIFF
--- a/alsgls/__init__.py
+++ b/alsgls/__init__.py
@@ -1,19 +1,6 @@
-
----
-
-# `alsgls/__init__.py`
-
-```python
 from .als import als_gls
 from .em import em_gls
 from .metrics import mse, nll_per_row
 from .sim import simulate_sur, simulate_gls
 
-__all__ = [
-    "als_gls",
-    "em_gls",
-    "mse",
-    "nll_per_row",
-    "simulate_sur",
-    "simulate_gls",
-]
+__all__ = ["als_gls", "em_gls", "mse", "nll_per_row", "simulate_sur", "simulate_gls"]


### PR DESCRIPTION
## Summary
- Clean up `alsgls/__init__.py` to remove markdown and keep only executable imports

## Testing
- `python -m pytest -q`
- `python -c "import alsgls"`

------
https://chatgpt.com/codex/tasks/task_e_68a2cd9ec7d0832f8957e0ca42997eb4