### PR TITLE
Expose CG solver stats

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -57,6 +57,7 @@ def als_gls(
 
     # main ALS loop
     prev = None
+    cg_info = None
     for _ in range(sweeps):
         # β-step via CG
         rhs_blocks = []
@@ -65,7 +66,7 @@ def als_gls(
             rhs_blocks.append(X.T @ S_y[:, [j]])
         b = np.concatenate(rhs_blocks, axis=0).ravel()
         bvec0 = stack_B_list(B)
-        bvec = cg_solve(A_mv, b, x0=bvec0, maxit=cg_maxit, tol=cg_tol, M_pre=M_pre)
+        bvec, cg_info = cg_solve(A_mv, b, x0=bvec0, maxit=cg_maxit, tol=cg_tol, M_pre=M_pre)
         B = unstack_B_vec(bvec, p_list)
 
         # factor step
@@ -89,5 +90,5 @@ def als_gls(
             prev = obj
 
     mem_mb_est = (K * F.shape[1] + K) * 8 / 1e6
-    info = {"p_list": p_list}
+    info = {"p_list": p_list, "cg": cg_info}
     return B, F, D, mem_mb_est, info

--- a/alsgls/ops.py
+++ b/alsgls/ops.py
@@ -53,16 +53,20 @@ def cg_solve(operator_mv, b, x0=None, maxit=500, tol=1e-7, M_pre=None):
     z = M_pre(r) if M_pre is not None else r
     p = z.copy()
     rz_old = float(r @ z)
+    iterations = 0
     for _ in range(maxit):
+        iterations += 1
         Ap = operator_mv(p)
         alpha = rz_old / max(1e-30, float(p @ Ap))
         x += alpha * p
         r -= alpha * Ap
-        if np.linalg.norm(r) <= tol * (np.linalg.norm(b) + 1e-30):
+        res_norm = np.linalg.norm(r)
+        if res_norm <= tol * (np.linalg.norm(b) + 1e-30):
             break
         z = M_pre(r) if M_pre is not None else r
         rz_new = float(r @ z)
         beta = rz_new / max(1e-30, rz_old)
         p = z + beta * p
         rz_old = rz_new
-    return x
+    info = {"iterations": iterations, "residual": float(np.linalg.norm(r))}
+    return x, info


### PR DESCRIPTION
## Summary
- track iterations and residual norm inside `cg_solve`
- adapt ALS solver to unpack CG info and return it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2d064e5f4832faf63f212d3937a72