### PR TITLE
Optimize Gram block computation for symmetric assembly

### DIFF
--- a/alsgls/em.py
+++ b/alsgls/em.py
@@ -41,8 +41,13 @@ def em_gls(Xs, Y, k, lam_F=1e-3, lam_B=1e-3, iters=30, d_floor=1e-8):
         F = np.pad(F, ((0, 0), (0, k - r)))
     D = np.maximum(np.var(R, axis=0), d_floor)
 
-    # Precompute Gram blocks
-    G = [[Xs[j].T @ Xs[l] for l in range(K)] for j in range(K)]
+    # Precompute Gram blocks X_j^T X_l.
+    # Only upper-triangular blocks are formed and the lower triangle is
+    # recovered via symmetry when assembling the normal-equation matrix.
+    G = [[None] * K for _ in range(K)]
+    for j in range(K):
+        for l in range(j, K):
+            G[j][l] = Xs[j].T @ Xs[l]
 
     for _ in range(iters):
         # E-step-like: nothing explicit (we directly update F,D after β)
@@ -56,17 +61,22 @@ def em_gls(Xs, Y, k, lam_F=1e-3, lam_B=1e-3, iters=30, d_floor=1e-8):
 
         A = np.zeros((sum(p_list), sum(p_list)))
         rhs = np.zeros((sum(p_list), 1))
-        # Blocks A_{j,l} = Σ^{-1}_{l,j} * X_j^T X_l
-        row = 0
+        p_offsets = np.cumsum([0] + p_list)
+        # Blocks A_{j,l} = Σ^{-1}_{l,j} * X_j^T X_l (symmetric in j,l)
         for j in range(K):
-            col = 0
             Sj = Sigma_inv[:, j]
-            for l in range(K):
-                A[row:row+G[j][l].shape[0], col:col+G[j][l].shape[1]] = Sj[l] * G[j][l]
-                col += G[j][l].shape[1]
-            rhs[row:row+G[j][j].shape[0], :] = Xs[j].T @ (Y @ Sj.reshape(-1, 1))
-            row += G[j][j].shape[0]
+            r0, r1 = p_offsets[j], p_offsets[j + 1]
+            rhs[r0:r1, :] = Xs[j].T @ (Y @ Sj.reshape(-1, 1))
+            for l in range(j, K):
+                c0, c1 = p_offsets[l], p_offsets[l + 1]
+                block = G[j][l]
+                scalar = Sj[l]
+                A[r0:r1, c0:c1] = scalar * block
+                if l != j:
+                    # Mirror to the symmetric block to maintain A symmetric
+                    A[c0:c1, r0:r1] = scalar * block.T
         A += lam_B * np.eye(A.shape[0])
+        A = (A + A.T) * 0.5  # enforce symmetry
         bvec = np.linalg.solve(A, rhs).ravel()
         B = []
         i = 0


### PR DESCRIPTION
## Summary
- Precompute only upper-triangular Gram blocks and mirror them when assembling the beta-step normal equations
- Symmetrize the normal-equation matrix before solving to maintain numerical symmetry

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2d5711358832f902e598b34ceb318