### PR TITLE
Precompute Woodbury pieces and allow caching

### DIFF
--- a/alsgls/ops.py
+++ b/alsgls/ops.py
@@ -14,11 +14,26 @@ def woodbury_pieces(F: np.ndarray, D: np.ndarray):
     Cf = np.linalg.inv(np.eye(F.shape[1]) + M)
     return Dinv, Cf
 
-def apply_siginv_to_matrix(M: np.ndarray, F: np.ndarray, D: np.ndarray):
+def apply_siginv_to_matrix(M: np.ndarray, F: np.ndarray, D: np.ndarray, *, Dinv=None, Cf=None):
+    """Right-multiply an N×K matrix ``M`` by ``Σ^{-1}`` using Woodbury.
+
+    Parameters
+    ----------
+    M : np.ndarray
+        Matrix to be multiplied on the right by ``Σ^{-1}``.
+    F : np.ndarray
+        Low-rank factor matrix.
+    D : np.ndarray
+        Diagonal entries of the noise covariance.
+    Dinv : np.ndarray, optional
+        Precomputed ``1/D`` vector.  If ``None`` (default), it will be
+        computed internally via :func:`woodbury_pieces`.
+    Cf : np.ndarray, optional
+        Precomputed ``(I + F^T D^{-1} F)^{-1}``.  If ``None`` (default), it
+        will be computed internally via :func:`woodbury_pieces`.
     """
-    Right-multiply an N x K matrix M by Σ^{-1} using Woodbury.
-    """
-    Dinv, Cf = woodbury_pieces(F, D)
+    if Dinv is None or Cf is None:
+        Dinv, Cf = woodbury_pieces(F, D)
     # M * Dinv - M*(Dinv F) Cf (F^T Dinv)
     MDinv = M * Dinv[None, :]
     T1 = MDinv @ F              # N x k

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -30,8 +30,12 @@ def test_woodbury_pieces_and_apply_siginv_to_matrix():
     # Validate apply_siginv_to_matrix against explicit inverse
     M = rng.standard_normal((3, K))
     expected = M @ Sigma_inv
+    # without cached pieces
     got = apply_siginv_to_matrix(M, F, D)
     assert np.allclose(got, expected, atol=1e-12, rtol=1e-12)
+    # with cached pieces
+    got_cached = apply_siginv_to_matrix(M, F, D, Dinv=Dinv, Cf=Cf)
+    assert np.allclose(got_cached, expected, atol=1e-12, rtol=1e-12)
 
 
 def test_stack_and_unstack_B_list():


### PR DESCRIPTION
## Summary
- Allow providing cached `Dinv` and `Cf` to `apply_siginv_to_matrix` to avoid redundant `woodbury_pieces` calls.
- Precompute Woodbury components once per ALS sweep and reuse them in matrix-vector products and RHS computations.
- Extend ops tests to cover the new cached-code path.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2d5814b7c832f8a0e6d6dd31ec146