### PR TITLE
Simplify nll_per_row interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ pip install -e .
 ### Usage
 
 ```python
-from alsgls import als_gls, simulate_sur
+from alsgls import als_gls, simulate_sur, nll_per_row, XB_from_Blist
 
 Xs_tr, Y_tr, Xs_te, Y_te = simulate_sur(N_tr=240, N_te=120, K=60, p=3, k=4)
 B, F, D, mem, _ = als_gls(Xs_tr, Y_tr, k=4)
+Yhat_te = XB_from_Blist(Xs_te, B)
+nll = nll_per_row(Y_te - Yhat_te, F, D)
 ```
 
 See `examples/compare_als_vs_em.py` for a complete ALS versus EM comparison.

--- a/alsgls/metrics.py
+++ b/alsgls/metrics.py
@@ -4,10 +4,23 @@ from .ops import woodbury_pieces
 def mse(Y, Yhat):
     return float(np.mean((Y - Yhat) ** 2))
 
-def nll_per_row(Y, R, F, D):
-    """
-    Negative log-likelihood per row for residual matrix R (N x K):
-    0.5 * [ tr(R Σ^{-1} R^T) + logdet(Σ) + K log(2π) ]
+def nll_per_row(R, F, D):
+    """Negative log-likelihood per row for residual matrix ``R``.
+
+    Parameters
+    ----------
+    R : ndarray (N × K)
+        Residual matrix.
+    F : ndarray (K × k)
+        Factor loadings.
+    D : ndarray (K,)
+        Diagonal noise variances.
+
+    Returns
+    -------
+    float
+        ``0.5 * [tr(R Σ^{-1} R^T) + logdet(Σ) + K log(2π)]``
+        averaged over rows.
     """
     K = R.shape[1]
     Dinv, Cf = woodbury_pieces(F, D)

--- a/examples/compare_als_vs_em.py
+++ b/examples/compare_als_vs_em.py
@@ -12,7 +12,7 @@ def main():
     sec_a = time.time() - t0
     Yhat_te_a = XB_from_Blist(Xs_te, B_a)
     m_a = mse(Y_te, Yhat_te_a)
-    nll_a = nll_per_row(Y_te, Y_te - Yhat_te_a, F_a, D_a)
+    nll_a = nll_per_row(Y_te - Yhat_te_a, F_a, D_a)
 
     # EM
     t0 = time.time()
@@ -20,7 +20,7 @@ def main():
     sec_e = time.time() - t0
     Yhat_te_e = XB_from_Blist(Xs_te, B_e)
     m_e = mse(Y_te, Yhat_te_e)
-    nll_e = nll_per_row(Y_te, Y_te - Yhat_te_e, F_e, D_e)
+    nll_e = nll_per_row(Y_te - Yhat_te_e, F_e, D_e)
 
     print("=== SUR (ALS vs EM) ===")
     print(f"K={K}  p={p}  k={k}  N_tr={N_tr}  N_te={N_te}")

--- a/tests/test_lowrank_gls.py
+++ b/tests/test_lowrank_gls.py
@@ -53,9 +53,9 @@ def test_als_vs_em_basic():
     # Check that NLL computation works
     R_als = Y_tr - XB_from_Blist(Xs_tr, B_als)
     R_em = Y_tr - XB_from_Blist(Xs_tr, B_em)
-    
-    nll_als = nll_per_row(Y_tr, R_als, F_als, D_als)
-    nll_em = nll_per_row(Y_tr, R_em, F_em, D_em)
+
+    nll_als = nll_per_row(R_als, F_als, D_als)
+    nll_em = nll_per_row(R_em, F_em, D_em)
     
     assert np.isfinite(nll_als) and np.isfinite(nll_em)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,7 +14,7 @@ def test_nll_matches_explicit():
     F = rng.normal(size=(K, k))
     D = rng.uniform(0.5, 1.5, size=K)
 
-    nll_func = nll_per_row(None, R, F, D)
+    nll_func = nll_per_row(R, F, D)
 
     Sigma = F @ F.T + np.diag(D)
     Sigma_inv = np.linalg.inv(Sigma)


### PR DESCRIPTION
## Summary
- remove unused `Y` parameter from `nll_per_row` and expand its documentation
- update examples and tests to pass residuals only
- document new usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d58c1a5c832fbfea9d71d90431c1