### PR TITLE
Optimize Woodbury scaling in ops helper

### DIFF
--- a/alsgls/ops.py
+++ b/alsgls/ops.py
@@ -9,7 +9,7 @@ def woodbury_pieces(F: np.ndarray, D: np.ndarray):
     D = np.asarray(D)
     Dinv = 1.0 / np.clip(D, 1e-12, None)
     FtDinv = (F.T * Dinv)           # k x K (row-scale F.T by Dinv)
-    M = F.T @ (F * Dinv[:, None])   # k x k == F^T D^{-1} F
+    M = FtDinv @ F                  # k x k == F^T D^{-1} F (reuse FtDinv to avoid re-scaling F)
     # solve small kxk: (I + M)^{-1}
     Cf = np.linalg.inv(np.eye(F.shape[1]) + M)
     return Dinv, Cf


### PR DESCRIPTION
## Summary
- Reuse pre-scaled `FtDinv` when forming `M` in `woodbury_pieces` to avoid scaling `F` twice
- Document the reuse with an inline comment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2d66b98bc832f953d2acb9d46e294