### PR TITLE
Use solve for factor updates

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -90,9 +90,9 @@ def als_gls(
         R = Y - XB_from_Blist(Xs, B)
         # update U (scores) and F (loadings) by two ridge solves
         FtF = F.T @ F + lam_F * np.eye(F.shape[1])
-        U = R @ F @ np.linalg.inv(FtF)
+        U = np.linalg.solve(FtF, (R @ F).T).T
         UtU = U.T @ U + lam_F * np.eye(F.shape[1])
-        F = R.T @ U @ np.linalg.inv(UtU)
+        F = np.linalg.solve(UtU, U.T @ R).T
 
         # diagonal noise
         D = np.maximum(np.mean((R - U @ F.T) ** 2, axis=0), d_floor)

--- a/alsgls/em.py
+++ b/alsgls/em.py
@@ -55,7 +55,7 @@ def em_gls(Xs, Y, k, lam_F=1e-3, lam_B=1e-3, iters=30, d_floor=1e-8):
         # β-step (dense normal equations using Σ^{-1})
         Dinv = 1.0 / np.clip(D, 1e-12, None)
         M = F.T @ (F * Dinv[:, None])             # k x k
-        Cf = np.linalg.inv(np.eye(k) + M)
+        Cf = np.linalg.solve(np.eye(k) + M, np.eye(k))
         # Build Σ^{-1} explicitly (KxK)
         Sigma_inv = np.diag(Dinv) - (F * Dinv[:, None]) @ Cf @ (F.T * Dinv[None, :])
 
@@ -88,9 +88,9 @@ def em_gls(Xs, Y, k, lam_F=1e-3, lam_B=1e-3, iters=30, d_floor=1e-8):
         R = Y - XB_from_Blist(Xs, B)
         # Update scores/loadings by two ridge solves
         FtF = F.T @ F + lam_F * np.eye(F.shape[1])
-        Uhat = R @ F @ np.linalg.inv(FtF)
+        Uhat = np.linalg.solve(FtF, (R @ F).T).T
         UtU = Uhat.T @ Uhat + lam_F * np.eye(F.shape[1])
-        F = R.T @ Uhat @ np.linalg.inv(UtU)
+        F = np.linalg.solve(UtU, Uhat.T @ R).T
         D = np.maximum(np.mean((R - Uhat @ F.T) ** 2, axis=0), d_floor)
 
     mem_mb_est = (K * K) * 8 / 1e6  # explicit Σ^{-1}

--- a/alsgls/ops.py
+++ b/alsgls/ops.py
@@ -11,7 +11,7 @@ def woodbury_pieces(F: np.ndarray, D: np.ndarray):
     FtDinv = (F.T * Dinv)           # k x K (row-scale F.T by Dinv)
     M = FtDinv @ F                  # k x k == F^T D^{-1} F (reuse FtDinv to avoid re-scaling F)
     # solve small kxk: (I + M)^{-1}
-    Cf = np.linalg.inv(np.eye(F.shape[1]) + M)
+    Cf = np.linalg.solve(np.eye(F.shape[1]) + M, np.eye(F.shape[1]))
     return Dinv, Cf
 
 def apply_siginv_to_matrix(M: np.ndarray, F: np.ndarray, D: np.ndarray, *, Dinv=None, Cf=None):


### PR DESCRIPTION
## Summary
- avoid forming explicit inverses in ALS factor step with `np.linalg.solve`
- update EM solver and woodbury helper to form Cf with `np.linalg.solve`
- keep solver numerically equivalent via unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2d915f5d0832fa8503a4bb6741ccc