### PR TITLE
Simplify diagonal inverse handling in ALS

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -1,6 +1,6 @@
 import numpy as np
 from .ops import (
-    apply_siginv_to_matrix, woodbury_pieces,
+    apply_siginv_to_matrix,
     stack_B_list, unstack_B_vec, XB_from_Blist, cg_solve
 )
 
@@ -52,14 +52,14 @@ def als_gls(
     prev = None
     cg_info = None
     for _ in range(sweeps):
-        # Precompute Woodbury pieces once per sweep
-        Dinv, Cf = woodbury_pieces(F, D)
+        # Precompute D^{-1} once per sweep for the preconditioner
+        Dinv = 1.0 / np.clip(D, 1e-12, None)
 
         def A_mv(bvec):
             """Matrix-free normal operator H(B) = X^T Σ^{-1} X · b + lam_B b"""
             B_dir = unstack_B_vec(bvec, p_list)
             M = XB_from_Blist(Xs, B_dir)                 # N x K
-            S = apply_siginv_to_matrix(M, F, D, Dinv=Dinv, Cf=Cf)  # N x K
+            S = apply_siginv_to_matrix(M, F, D)  # N x K
             out_blocks = []
             for j, X in enumerate(Xs):
                 out_blocks.append(X.T @ S[:, [j]])
@@ -78,7 +78,7 @@ def als_gls(
 
         # β-step via CG
         rhs_blocks = []
-        S_y = apply_siginv_to_matrix(Y, F, D, Dinv=Dinv, Cf=Cf)
+        S_y = apply_siginv_to_matrix(Y, F, D)
         for j, X in enumerate(Xs):
             rhs_blocks.append(X.T @ S_y[:, [j]])
         b = np.concatenate(rhs_blocks, axis=0).ravel()


### PR DESCRIPTION
## Summary
- Precompute diagonal inverse once per sweep and reuse in preconditioner
- Drop unused Woodbury components and simplify Σ^{-1} applications

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2d6b7abe0832f9dfc720ad16e6064