### PR TITLE
Expose Woodbury pieces for cached NLL computations

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -53,7 +53,7 @@ def als_gls(
     cg_info = None
     for _ in range(sweeps):
         # Precompute Woodbury pieces once per sweep
-        Dinv, Cf = woodbury_pieces(F, D)
+        Dinv, Cf, _ = woodbury_pieces(F, D)
 
         def A_mv(bvec):
             """Matrix-free normal operator H(B) = X^T Σ^{-1} X · b + lam_B b"""

--- a/alsgls/metrics.py
+++ b/alsgls/metrics.py
@@ -4,7 +4,7 @@ from .ops import woodbury_pieces
 def mse(Y, Yhat):
     return float(np.mean((Y - Yhat) ** 2))
 
-def nll_per_row(R, F, D):
+def nll_per_row(R, F, D, *, Dinv=None, Cf=None):
     """Negative log-likelihood per row for residual matrix ``R``.
 
     Parameters
@@ -15,6 +15,12 @@ def nll_per_row(R, F, D):
         Factor loadings.
     D : ndarray (K,)
         Diagonal noise variances.
+    Dinv : ndarray (K,), optional
+        Precomputed ``1/D`` values.  If ``None`` (default) they are computed
+        internally via :func:`woodbury_pieces`.
+    Cf : ndarray (k × k), optional
+        Precomputed ``(I + F^T D^{-1} F)^{-1}``.  If ``None`` (default) it is
+        computed internally via :func:`woodbury_pieces`.
 
     Returns
     -------
@@ -23,7 +29,8 @@ def nll_per_row(R, F, D):
         averaged over rows.
     """
     K = R.shape[1]
-    Dinv, Cf = woodbury_pieces(F, D)
+    if Dinv is None or Cf is None:
+        Dinv, Cf, _ = woodbury_pieces(F, D)
     # tr(R Σ^{-1} R^T) = sum over rows of r Σ^{-1} r^T
     # Efficiently: R Σ^{-1} = apply_siginv_to_matrix(R, F, D), but avoid circular import.
     # Inline Woodbury:
@@ -34,6 +41,8 @@ def nll_per_row(R, F, D):
     quad = float(np.sum(RSinv * R))
     # logdet via matrix determinant lemma:
     # det(FF^T + D) = det(D) det(I + F^T D^{-1} F)
-    logdet = float(np.sum(np.log(np.clip(D, 1e-12, None)))) \
-             + float(np.linalg.slogdet(np.eye(F.shape[1]) + F.T @ (F * Dinv[:, None]))[1])
+    # Use Cf = (I + F^T D^{-1} F)^{-1} to avoid recomputing F^T D^{-1} F
+    logdet = float(
+        np.sum(np.log(np.clip(D, 1e-12, None))) - np.linalg.slogdet(Cf)[1]
+    )
     return 0.5 * (quad / R.shape[0] + logdet + K * np.log(2 * np.pi))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -23,18 +23,19 @@ def test_woodbury_pieces_and_apply_siginv_to_matrix():
     Sigma_inv = np.linalg.inv(Sigma)
 
     # Validate woodbury_pieces
-    Dinv, Cf = woodbury_pieces(F, D)
+    Dinv, Cf, M = woodbury_pieces(F, D)
     Sigma_inv_wb = np.diag(Dinv) - (F * Dinv[:, None]) @ Cf @ (F.T * Dinv)
     assert np.allclose(Sigma_inv_wb, Sigma_inv, atol=1e-12, rtol=1e-12)
+    assert np.allclose(M, F.T @ (F * Dinv[:, None]))
 
     # Validate apply_siginv_to_matrix against explicit inverse
-    M = rng.standard_normal((3, K))
-    expected = M @ Sigma_inv
+    X = rng.standard_normal((3, K))
+    expected = X @ Sigma_inv
     # without cached pieces
-    got = apply_siginv_to_matrix(M, F, D)
+    got = apply_siginv_to_matrix(X, F, D)
     assert np.allclose(got, expected, atol=1e-12, rtol=1e-12)
     # with cached pieces
-    got_cached = apply_siginv_to_matrix(M, F, D, Dinv=Dinv, Cf=Cf)
+    got_cached = apply_siginv_to_matrix(X, F, D, Dinv=Dinv, Cf=Cf)
     assert np.allclose(got_cached, expected, atol=1e-12, rtol=1e-12)
 
 


### PR DESCRIPTION
## Summary
- Extend `woodbury_pieces` to also return the intermediate matrix `M = F.T @ (F * Dinv[:, None])`
- Compute log-determinant in `nll_per_row` using cached `Cf` and optional `Dinv`/`Cf` parameters
- Update ALS and related utilities/tests to use the enhanced API and verify cached code paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2d9243ba0832f92ba42934ef808bc