### PR TITLE
Improve ALS GLS preconditioner with column norm scaling

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -72,7 +72,7 @@ def als_gls(
             # Rough diag: X_j^T (Σ^{-1} e_j e_j^T) X_j ≈ X_j^T (Dinv_j) X_j
             for j, X in enumerate(Xs):
                 w = float(Dinv[j])
-                diag_entries.extend([w] * X.shape[1])
+                diag_entries.extend(w * np.sum(X**2, axis=0))
             d = np.array(diag_entries) + lam_B
             return v / np.maximum(d, 1e-8)
 


### PR DESCRIPTION
## Summary
- Scale each coefficient's diagonal preconditioner entry by the weighted column norms of its design matrix in `als_gls`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2da0815e8832f95ea472a28e3c54c