### PR TITLE
Clarify diagonal preconditioner in ALS

### DIFF
--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -69,10 +69,14 @@ def als_gls(
         # simple diagonal preconditioner: approx diag of H
         def M_pre(v):
             diag_entries = []
-            # Rough diag: X_j^T (Σ^{-1} e_j e_j^T) X_j ≈ X_j^T (Dinv_j) X_j
+            # Rough diag: X_j^T (Σ^{-1} e_j e_j^T) X_j
+            # Only uses per-equation diagonal Σ^{-1}≈Dinv[j]; cross-equation
+            # Woodbury corrections from F are neglected, which can weaken the
+            # preconditioner when cross-equation correlations are strong.
             for j, X in enumerate(Xs):
-                w = float(Dinv[j])
-                diag_entries.extend(w * np.sum(X**2, axis=0))
+                # Explicitly form diag(X_j^T X_j) for clarity
+                diag = np.diag(X.T @ X)
+                diag_entries.extend(Dinv[j] * diag)
             d = np.array(diag_entries) + lam_B
             return v / np.maximum(d, 1e-8)
 


### PR DESCRIPTION
## Summary
- Clarify the diagonal preconditioner by explicitly forming `diag(X.T @ X)` and scaling by `Dinv[j]`
- Document that cross-equation Woodbury corrections are ignored and may weaken the preconditioner when correlations are strong

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2dcb25e04832fa985bde8f81cdf42