### PR TITLE
Clarify Woodbury inverse variable naming

### DIFF
--- a/alsgls/em.py
+++ b/alsgls/em.py
@@ -47,9 +47,9 @@ def em_gls(Xs, Y, k, lam_F=1e-3, lam_B=1e-3, iters=30, d_floor=1e-8):
         # β-step (dense normal equations using Σ^{-1})
         Dinv = 1.0 / np.clip(D, 1e-12, None)
         M = F.T @ (F * Dinv[:, None])             # k x k
-        Cf = np.linalg.solve(np.eye(k) + M, np.eye(k))
+        C_inv = np.linalg.solve(np.eye(k) + M, np.eye(k))  # (I + F^T D^{-1} F)^{-1}
         # Build Σ^{-1} explicitly (KxK)
-        Sigma_inv = np.diag(Dinv) - (F * Dinv[:, None]) @ Cf @ (F.T * Dinv[None, :])
+        Sigma_inv = np.diag(Dinv) - (F * Dinv[:, None]) @ C_inv @ (F.T * Dinv[None, :])
 
         A = np.zeros((sum(p_list), sum(p_list)))
         rhs = np.zeros((sum(p_list), 1))

--- a/alsgls/metrics.py
+++ b/alsgls/metrics.py
@@ -23,13 +23,13 @@ def nll_per_row(R, F, D):
         averaged over rows.
     """
     K = R.shape[1]
-    Dinv, Cf = woodbury_pieces(F, D)
+    Dinv, C_inv = woodbury_pieces(F, D)  # C_inv = (I + F^T D^{-1} F)^{-1}
     # tr(R Σ^{-1} R^T) = sum over rows of r Σ^{-1} r^T
     # Efficiently: R Σ^{-1} = apply_siginv_to_matrix(R, F, D), but avoid circular import.
     # Inline Woodbury:
     RDinv = R * Dinv[None, :]
     T1 = RDinv @ F          # N x k
-    T2 = T1 @ Cf            # N x k
+    T2 = T1 @ C_inv         # N x k
     RSinv = RDinv - T2 @ (F.T * Dinv)  # N x K
     quad = float(np.sum(RSinv * R))
     # logdet via matrix determinant lemma:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -23,8 +23,8 @@ def test_woodbury_pieces_and_apply_siginv_to_matrix():
     Sigma_inv = np.linalg.inv(Sigma)
 
     # Validate woodbury_pieces
-    Dinv, Cf = woodbury_pieces(F, D)
-    Sigma_inv_wb = np.diag(Dinv) - (F * Dinv[:, None]) @ Cf @ (F.T * Dinv)
+    Dinv, C_inv = woodbury_pieces(F, D)
+    Sigma_inv_wb = np.diag(Dinv) - (F * Dinv[:, None]) @ C_inv @ (F.T * Dinv)
     assert np.allclose(Sigma_inv_wb, Sigma_inv, atol=1e-12, rtol=1e-12)
 
     # Validate apply_siginv_to_matrix against explicit inverse
@@ -34,7 +34,7 @@ def test_woodbury_pieces_and_apply_siginv_to_matrix():
     got = apply_siginv_to_matrix(M, F, D)
     assert np.allclose(got, expected, atol=1e-12, rtol=1e-12)
     # with cached pieces
-    got_cached = apply_siginv_to_matrix(M, F, D, Dinv=Dinv, Cf=Cf)
+    got_cached = apply_siginv_to_matrix(M, F, D, Dinv=Dinv, C_inv=C_inv)
     assert np.allclose(got_cached, expected, atol=1e-12, rtol=1e-12)
 
 


### PR DESCRIPTION
## Summary
- rename ambiguous `Cf` variable to `C_inv` in Woodbury helpers
- clarify docs that `C_inv` is the inverse of `(I + F^T D^{-1} F)`
- update call sites and tests for the new terminology

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2dc986ac4832fa40922ec4439d4ce