### PR TITLE
Fix 6.48x-too-wide confidence intervals, an un-disableable ridge, and a dead line search

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,23 @@ jobs:
         run: |
           python3 .github/scripts/process_readme.py
           
+      # On a pull_request, actions/checkout leaves a detached HEAD at the merge
+      # commit, so committing and pushing fails outright with "You are not
+      # currently on a branch". Verify instead: if the regenerated README
+      # differs from the committed one, the template and the file are out of
+      # step and that is worth failing the PR for.
+      - name: Verify README matches the template
+        if: github.event_name == 'pull_request'
+        run: |
+          git diff --exit-code README.md || {
+            echo "README.md is out of date. Regenerate it with"
+            echo "  python3 .github/scripts/process_readme.py"
+            echo "and commit the result."
+            exit 1
+          }
+
       - name: Commit changes
+        if: github.event_name != 'pull_request'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"

--- a/alsgls/_validation.py
+++ b/alsgls/_validation.py
@@ -206,7 +206,12 @@ def _sanitize_regularization_params(
                 f"Try lam_B=1e-3 for light regularization."
             )
 
-    return float(lam_F or 1e-3), float(lam_B or 1e-3)
+    # ``x or default`` would discard an explicit 0.0, which the checks above
+    # accept as a valid ("non-negative") request for no regularization.
+    return (
+        float(1e-3 if lam_F is None else lam_F),
+        float(1e-3 if lam_B is None else lam_B),
+    )
 
 
 def _validate_gls_inputs(

--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -98,7 +98,25 @@ def als_gls(
         p = X.shape[1]
         XtX = X.T @ X + lam_B * np.eye(p)
         Xty = X.T @ Y[:, [j]]
-        B.append(np.linalg.solve(XtX, Xty))
+        try:
+            B.append(np.linalg.solve(XtX, Xty))
+        except np.linalg.LinAlgError as exc:
+            # lam_B used to be floored at 1e-3 by a falsy-zero bug, so a
+            # rank-deficient design was quietly ridged into solvability. Now
+            # that lam_B = 0 means zero, say what happened rather than letting
+            # a bare "Singular matrix" out -- and do not silently substitute a
+            # pseudo-inverse, which would be the same kind of quiet
+            # substitution that hid this in the first place.
+            msg = (
+                f"Equation {j} has a singular X'X"
+                + (
+                    " and lam_B is 0, so there is nothing to regularize it. "
+                    "Drop the collinear columns or pass lam_B > 0."
+                    if lam_B == 0
+                    else f" even with lam_B={lam_B}. Drop the collinear columns."
+                )
+            )
+            raise np.linalg.LinAlgError(msg) from exc
 
     # Residuals
     R = Y - XB_from_Blist(Xs, B)

--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -107,14 +107,11 @@ def als_gls(
             # a bare "Singular matrix" out -- and do not silently substitute a
             # pseudo-inverse, which would be the same kind of quiet
             # substitution that hid this in the first place.
-            msg = (
-                f"Equation {j} has a singular X'X"
-                + (
-                    " and lam_B is 0, so there is nothing to regularize it. "
-                    "Drop the collinear columns or pass lam_B > 0."
-                    if lam_B == 0
-                    else f" even with lam_B={lam_B}. Drop the collinear columns."
-                )
+            msg = f"Equation {j} has a singular X'X" + (
+                " and lam_B is 0, so there is nothing to regularize it. "
+                "Drop the collinear columns or pass lam_B > 0."
+                if lam_B == 0
+                else f" even with lam_B={lam_B}. Drop the collinear columns."
             )
             raise np.linalg.LinAlgError(msg) from exc
 

--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -135,8 +135,22 @@ def als_gls(
     else:
         F = np.zeros((K, k))
 
+    # D is a variance, so its floor has to be a variance too. A fixed absolute
+    # floor is not scale-equivariant: under Y -> sY the true D scales as s^2,
+    # so for small enough s every entry lands on the floor and the fit stops
+    # tracking the data. Measured on B, which must satisfy B(sY) == B(Y):
+    # the error saturated at 2.6e-2 for s <= 1e-4 with an absolute 1e-8.
+    # Taken relative to the residual variance scale, d_floor keeps its meaning
+    # ("no variance below this fraction of a typical one") and transforms
+    # correctly. The reference is fixed once, so it does not drift between
+    # sweeps.
+    var_ref = float(np.mean(np.var(R, axis=0)))
+    if not np.isfinite(var_ref) or var_ref <= 0.0:
+        var_ref = 1.0
+    d_floor_eff = d_floor * var_ref
+
     # Diagonal noise (start from residual variances, floored)
-    D = np.maximum(np.var(R, axis=0), d_floor)
+    D = np.maximum(np.var(R, axis=0), d_floor_eff)
 
     # ----------------------------
     # Traces & baseline
@@ -231,7 +245,7 @@ def als_gls(
         diag_S = np.sum(R**2, axis=0) / N
 
         def D_mle(F_try):
-            return np.maximum(diag_S - np.sum(F_try**2, axis=1), d_floor)
+            return np.maximum(diag_S - np.sum(F_try**2, axis=1), d_floor_eff)
 
         # Guarded scale correction helper (applied to a candidate F,D)
         def try_with_scale(F_try, D_try):

--- a/alsgls/als.py
+++ b/alsgls/als.py
@@ -17,6 +17,11 @@ from .ops import (
     woodbury_chol,
 )
 
+# Maximum number of step halvings in the F/D backtracking line search.
+# 40 halvings reach t ~ 9e-13, enough to find an improving step at any data
+# scale encountered in double precision.
+_MAX_BACKTRACK = 40
+
 
 def als_gls(
     Xs: list[np.ndarray],
@@ -182,13 +187,33 @@ def als_gls(
         # Compute gradient of NLL w.r.t. F
         grad_F = grad_F_nll(R, F, D, Dinv, C_chol, lam_F)
 
-        # Steepest descent direction
-        F_prop = F - grad_F  # Step size handled in backtracking
+        # Steepest descent direction.
+        dF = -grad_F
 
-        # D update: MLE estimate diag(S - F F^T) where S = R^T R / N
+        # Scale-calibrated initial step length.
+        #
+        # The NLL is equivariant under Y -> sY, (F, D) -> (sF, s^2 D) up to an
+        # additive K log s, so grad_F scales like 1/s while F scales like s.
+        # A hard-coded unit step is therefore off by a factor of s^2: on
+        # small-magnitude data (e.g. returns expressed as decimals) it
+        # overshoots by orders of magnitude, every backtracked candidate is
+        # rejected, and F stays frozen at its initialization -- not a
+        # stationary point (docs/source/formal_methods.md, Theorems 1-2).
+        # Taking t0 = ||F|| / ||grad_F|| makes the trial step transform the
+        # same way F does, so the whole iteration is scale-equivariant.
+        gnorm = float(np.linalg.norm(dF))
+        fnorm = float(np.linalg.norm(F))
+        if gnorm > 0.0:
+            t0 = (fnorm / gnorm) if fnorm > 0.0 else (1.0 / gnorm)
+        else:
+            t0 = 0.0
+
+        # D update: closed-form MLE given the trial F,
+        # d_j = max(S_jj - (F F^T)_jj, d_floor)  with  S = R^T R / N.
         diag_S = np.sum(R**2, axis=0) / N
-        diag_FFt = np.sum(F_prop**2, axis=1)
-        D_prop = np.maximum(diag_S - diag_FFt, d_floor)
+
+        def D_mle(F_try):
+            return np.maximum(diag_S - np.sum(F_try**2, axis=1), d_floor)
 
         # Guarded scale correction helper (applied to a candidate F,D)
         def try_with_scale(F_try, D_try):
@@ -215,19 +240,24 @@ def als_gls(
             else:
                 return F_try, D_try, nll0, 1.0
 
-        # --- Backtracking/damped acceptance on (F, D)
+        # --- Backtracking line search on (F, D)
         F_old, D_old = F, D
-        dF = F_prop - F_old
-        dD = D_prop - D_old
 
         best_nll = base_nll
         best_F, best_D = F_old, D_old
         accepted_t = 0.0
         used_scale = 1.0
 
-        for t in (1.0, 0.5, 0.25, 0.125, 0.0625):
+        # Halve the step until it improves the NLL. Backtracking must be
+        # allowed to run to convergence: a ladder truncated at a fixed t_min
+        # rejects every candidate whenever the initial step overshoots, which
+        # silently freezes the F-step instead of finding a descent step.
+        t = t0
+        for _ in range(_MAX_BACKTRACK):
+            if t == 0.0:
+                break
             F_try = F_old + t * dF
-            D_try = np.maximum(D_old + t * dD, d_floor)
+            D_try = D_mle(F_try)
             F_acc, D_acc, nll_acc, sc_used = try_with_scale(F_try, D_try)
             # Accept only if we beat the per-sweep baseline
             if nll_acc < best_nll - 1e-12:
@@ -236,6 +266,7 @@ def als_gls(
                 accepted_t = t
                 used_scale = sc_used
                 break  # first improving step is fine (monotone)
+            t *= 0.5
 
         # Accept (or keep old F,D if no improvement)
         F, D = best_F, best_D

--- a/alsgls/api.py
+++ b/alsgls/api.py
@@ -204,6 +204,18 @@ class ALSGLS:
         if not getattr(self, "is_fitted_", False):
             raise RuntimeError("The estimator has not been fitted yet")
 
+    def _resid_df(self) -> int:
+        """Residual degrees of freedom of the stacked system.
+
+        The SUR system stacks ``K`` equations of ``N`` rows each, so it has
+        ``N * K`` observations, not ``N``.  Subtracting the system-wide
+        parameter count from the per-equation row count instead mixes two
+        different sample sizes and goes negative as soon as ``p_total > N``.
+        """
+        self._ensure_fitted()
+        n_total = self.n_obs_ * self.n_targets_
+        return max(n_total - sum(self.n_features_in_), 1)
+
     def predict(self, Xs: Sequence[Any]) -> np.ndarray:
         self._ensure_fitted()
         X_list = [_asarray_2d(X) for X in Xs]
@@ -290,8 +302,7 @@ class ALSGLS:
             include_residual=include_residual,
         )
 
-        df = self.n_obs_ - sum(self.n_features_in_)
-        df = max(df, 1)
+        df = self._resid_df()
         q = stats.t.ppf(1 - alpha / 2, df)
         se = np.sqrt(np.maximum(variance, 0.0))
 
@@ -548,12 +559,24 @@ class ALSGLSSystemResults:
             t = np.where(se > 0, self.params / se, 0.0)
         return t
 
+    def _resid_df(self) -> int:
+        """Residual degrees of freedom of the stacked system.
+
+        The system stacks ``keqs`` equations of ``nobs`` rows each, so the
+        total number of observations is ``nobs * keqs``.
+        """
+        n_total = self.model.nobs * self.model.keqs
+        return max(n_total - len(self.params), 1)
+
+    @property
+    def df_resid(self) -> int:
+        """Residual degrees of freedom: ``nobs * keqs - n_params``."""
+        return self._resid_df()
+
     @property
     def pvalues(self) -> np.ndarray:
         """Two-sided p-values for H₀: β = 0."""
-        df = self.model.nobs - len(self.params)
-        df = max(df, 1)
-        return 2.0 * stats.t.sf(np.abs(self.tvalues), df)
+        return 2.0 * stats.t.sf(np.abs(self.tvalues), self._resid_df())
 
     def conf_int(self, alpha: float = 0.05) -> np.ndarray:
         """Confidence intervals for parameters.
@@ -568,9 +591,7 @@ class ALSGLSSystemResults:
         ci : np.ndarray
             (n_params, 2) array with lower and upper bounds
         """
-        df = self.model.nobs - len(self.params)
-        df = max(df, 1)
-        q = stats.t.ppf(1 - alpha / 2, df)
+        q = stats.t.ppf(1 - alpha / 2, self._resid_df())
         se = self.bse
         lower = self.params - q * se
         upper = self.params + q * se
@@ -624,8 +645,7 @@ class ALSGLSSystemResults:
         se_mean = np.sqrt(np.maximum(var_mean, 0.0))
         se_obs = np.sqrt(np.maximum(var_obs, 0.0))
 
-        df = self.model.nobs - len(self.params)
-        df = max(df, 1)
+        df = self._resid_df()
 
         return PredictionResults(
             predicted_mean=predicted_mean,

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -226,3 +226,28 @@ def test_predict_interval_uses_stacked_df():
         )
     )
     np.testing.assert_allclose(half / se, stats.t.ppf(0.975, expected_df), rtol=1e-8)
+
+
+def test_zero_ridge_on_a_singular_design_explains_itself():
+    """lam_B = 0 on a rank-deficient X must say why, not emit "Singular matrix".
+
+    lam_B was floored at 1e-3 by a falsy-zero bug, so a rank-deficient design
+    was quietly ridged into solvability. Honouring lam_B = 0 exposes the
+    singularity, which is correct -- but the message has to name the cause,
+    and it must not silently substitute a pseudo-inverse, which would be the
+    same class of quiet substitution the falsy-zero fix removed.
+    """
+    import numpy as np
+    import pytest
+
+    from alsgls import als_gls
+
+    n = 10
+    x = np.c_[np.ones(n), np.ones(n)]  # duplicated column: rank 1 of 2
+    y = np.c_[np.linspace(0, 1, n), np.linspace(1, 0, n)]
+
+    with pytest.raises(np.linalg.LinAlgError, match="lam_B is 0"):
+        als_gls([x, x], y, k=1, lam_B=0.0, lam_F=0.0, sweeps=1)
+
+    # A positive ridge still solves it.
+    als_gls([x, x], y, k=1, lam_B=1e-3, lam_F=1e-3, sweeps=1)

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -1,0 +1,228 @@
+"""Regression tests for defects found by the correctness audit.
+
+Each test is pinned to a contract the package states about itself, and each
+one fails on the code as it stood before the accompanying fix.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy import stats
+
+from alsgls import ALSGLS, ALSGLSSystem, simulate_sur
+from alsgls._validation import _sanitize_regularization_params
+from alsgls.als import als_gls
+from alsgls.metrics import nll_per_row
+from alsgls.ops import (
+    XB_from_Blist,
+    compute_prediction_variance,
+    grad_F_nll,
+    woodbury_chol,
+)
+
+
+class TestRegularizationIsNotOverridden:
+    """``_sanitize_regularization_params`` validates that lam >= 0 is legal.
+
+    An explicit request for lam = 0 must therefore be honoured, not replaced
+    by the default.
+    """
+
+    @pytest.mark.parametrize("lam", [0.0, 0])
+    def test_zero_is_preserved_by_the_validator(self, lam):
+        lam_F, lam_B = _sanitize_regularization_params(lam, lam)
+        assert lam_F == 0.0
+        assert lam_B == 0.0
+
+    def test_none_still_yields_the_documented_default(self):
+        assert _sanitize_regularization_params(None, None) == (1e-3, 1e-3)
+
+    def test_zero_ridge_changes_the_fit(self):
+        """lam=0 must not produce the same numbers as the default lam=1e-3."""
+        Xs, Y, _, _ = simulate_sur(N_tr=80, N_te=5, K=5, p=3, k=2, seed=3)
+        B0, _, _, _, _ = als_gls(Xs, Y, k=2, sweeps=1, lam_F=0.0, lam_B=0.0)
+        Bd, _, _, _, _ = als_gls(Xs, Y, k=2, sweeps=1, lam_F=1e-3, lam_B=1e-3)
+        delta = max(np.abs(a - b).max() for a, b in zip(B0, Bd, strict=True))
+        assert delta > 0.0, "lam=0 was silently replaced by the default"
+
+    def test_zero_ridge_solves_the_unregularised_gls_normal_equations(self):
+        """With lam_B=0 the beta-step target is X'S^-1 X b = X'S^-1 y exactly."""
+        from alsgls.ops import apply_siginv_to_matrix, compute_XtSigmaInvX
+
+        Xs, Y, _, _ = simulate_sur(N_tr=80, N_te=5, K=5, p=3, k=2, seed=3)
+        B, F, D, _, _ = als_gls(Xs, Y, k=2, sweeps=20, lam_F=0.0, lam_B=0.0)
+
+        A = compute_XtSigmaInvX(Xs, F, D, lam_B=0.0)
+        S_y = apply_siginv_to_matrix(Y, F, D, C_chol=woodbury_chol(F, D)[1])
+        rhs = np.concatenate([Xs[j].T @ S_y[:, [j]] for j in range(len(Xs))]).ravel()
+        beta = np.concatenate([b.ravel() for b in B])
+
+        resid = A @ beta - rhs
+        assert np.abs(resid).max() / np.abs(rhs).max() < 1e-5, (
+            "returned beta does not solve the unregularised GLS normal "
+            f"equations; relative residual {np.abs(resid).max() / np.abs(rhs).max():.3e}"
+        )
+
+
+class TestFStepLineSearch:
+    """docs/source/formal_methods.md Sec. 5-6.
+
+    "The F-step uses gradient descent with backtracking line search";
+    "Theorem 2 (Convergence to Stationary Point)".
+
+    A backtracking line search shrinks the step until it finds an improving
+    one. It may not abandon the search while a descent step is still
+    available, and its first trial step must be calibrated to the problem
+    rather than hard-coded to 1.
+    """
+
+    @staticmethod
+    def _small_scale_problem():
+        # Magnitude used by examples/real_data_fama_french.py, which converts
+        # percentage returns to decimals (Y ~ 1e-2).
+        Xs, Y, _, _ = simulate_sur(N_tr=200, N_te=10, K=10, p=3, k=3, seed=5)
+        return Xs, Y / 100.0
+
+    def test_f_step_is_updated_on_small_scale_data(self):
+        """F must actually move; accept_t must not be identically zero."""
+        Xs, Y = self._small_scale_problem()
+        _, _, _, _, info = als_gls(Xs, Y, k=3, sweeps=30)
+        assert max(info["accept_t"]) > 0.0, (
+            f"line search accepted no step at any sweep: {info['accept_t']}"
+        )
+
+    def test_no_improving_step_remains_along_the_descent_direction(self):
+        """The line search must not stop while a descent step still helps.
+
+        Step sizes are probed relative to the scale-calibrated reference step
+        ``t0 = ||F|| / ||grad_F||`` so that the check means the same thing at
+        every data scale.
+        """
+        Xs, Y = self._small_scale_problem()
+        B, F, D, _, _ = als_gls(Xs, Y, k=3, sweeps=30)
+        R = Y - XB_from_Blist(Xs, B)
+        Dinv, C_chol = woodbury_chol(F, D)
+        dF = -grad_F_nll(R, F, D, Dinv, C_chol, 1e-3)
+
+        t0 = np.linalg.norm(F) / np.linalg.norm(dF)
+        diag_S = np.sum(R**2, axis=0) / R.shape[0]
+        nll_returned = float(nll_per_row(R, F, D))
+
+        best = nll_returned
+        t = t0
+        for _ in range(40):
+            F_try = F + t * dF
+            D_try = np.maximum(diag_S - np.sum(F_try**2, axis=1), 1e-8)
+            best = min(best, float(nll_per_row(R, F_try, D_try)))
+            t *= 0.5
+
+        assert nll_returned - best < 1e-3, (
+            f"a step along the same descent direction improves the NLL by "
+            f"{nll_returned - best:.6f} per row, so the search stopped early"
+        )
+
+    @pytest.mark.parametrize("s", [1e-2, 1e2])
+    def test_unpenalised_fit_is_scale_equivariant(self, s):
+        """With no ridge, rescaling the data must rescale the fit exactly.
+
+        The Gaussian NLL satisfies l(sY; sB, sF, s^2 D) = l(Y; B, F, D)
+        + K log s, so an unpenalised solver run on ``sY`` must trace the
+        rescaled iterates of the run on ``Y``.  (The ridge terms are absolute
+        and therefore scale-dependent by construction, which is why this is
+        asserted at lam=0; ``d_floor`` is a variance floor and is matched to
+        the scale for the same reason.)
+        """
+        Xs, Y, _, _ = simulate_sur(N_tr=120, N_te=10, K=8, p=3, k=2, seed=1)
+        kw = {"k": 2, "sweeps": 30, "lam_F": 0.0, "lam_B": 0.0}
+        B1, F1, D1, _, _ = als_gls(Xs, Y, **kw)
+        _, _, _, _, infos = als_gls(
+            Xs, s * Y, d_floor=1e-8 * s * s, scale_floor=1e-8 * s * s, **kw
+        )
+
+        R = s * Y - XB_from_Blist(Xs, [s * b for b in B1])
+        ref = float(nll_per_row(R, s * F1, s * s * D1))
+        got = infos["nll_trace"][-1]
+        assert got == pytest.approx(ref, abs=1e-5), (
+            f"at scale s={s} the solver reaches NLL {got:.8f} but the exactly "
+            f"rescaled unit-scale fit gives {ref:.8f}"
+        )
+
+
+class TestResidualDegreesOfFreedom:
+    """Inference must use the stacked system's sample size.
+
+    A SUR system of ``K`` equations with ``N`` rows each has ``N * K``
+    observations. Subtracting a system-wide parameter count from ``N`` alone
+    mixes two different sample sizes and goes negative once ``p_total > N``,
+    silently clamping the t reference distribution to 1 d.o.f.
+    """
+
+    @staticmethod
+    def _wide_system(K=120, N=300, p=3):
+        # The README's own benchmark grid: N=300, p=3, K up to 120.
+        Xs, Y, _, _ = simulate_sur(N_tr=N, N_te=5, K=K, p=p, k=3, seed=11)
+        system = {f"eq{j}": (Y[:, j], Xs[j]) for j in range(K)}
+        return Xs, Y, ALSGLSSystem(system, rank=3, max_sweeps=6).fit()
+
+    def test_system_df_uses_total_observations(self):
+        _, _, res = self._wide_system()
+        expected = res.model.nobs * res.model.keqs - len(res.params)
+        assert expected > 0
+        assert res.df_resid == expected
+
+    def test_wide_system_df_does_not_collapse(self):
+        _, _, res = self._wide_system()
+        assert len(res.params) > res.model.nobs, "test setup must have p_total > N"
+        assert res.df_resid > 1, (
+            "d.o.f. collapsed to 1; the t reference distribution is wrong"
+        )
+
+    def test_conf_int_width_matches_correct_df(self):
+        _, _, res = self._wide_system()
+        ci = res.conf_int(0.05)
+        half = (ci[:, 1] - ci[:, 0]) / 2.0
+        q = stats.t.ppf(0.975, res.model.nobs * res.model.keqs - len(res.params))
+        np.testing.assert_allclose(half, q * res.bse, rtol=1e-10)
+
+    def test_pvalues_use_correct_df(self):
+        _, _, res = self._wide_system()
+        q = stats.t.ppf(0.975, res.df_resid)
+        # t(0.975, df=1) = 12.71 vs t(0.975, df=35640) = 1.96.
+        assert q < 2.0
+        np.testing.assert_allclose(
+            res.pvalues, 2.0 * stats.t.sf(np.abs(res.tvalues), res.df_resid)
+        )
+
+
+@pytest.mark.parametrize("s", [1e-3, 1.0, 1e3])
+def test_nll_trace_is_self_consistent_at_any_scale(s):
+    """info['nll_trace'][-1] must equal the NLL recomputed from the output."""
+    Xs, Y, _, _ = simulate_sur(N_tr=100, N_te=5, K=6, p=2, k=2, seed=4)
+    B, F, D, _, info = als_gls(Xs, s * Y, k=2, sweeps=20)
+    R = s * Y - XB_from_Blist(Xs, B)
+    assert info["nll_trace"][-1] == pytest.approx(
+        float(nll_per_row(R, F, D)), rel=1e-12, abs=1e-12
+    )
+
+
+def test_predict_interval_uses_stacked_df():
+    """ALSGLS.predict_interval must use the same corrected d.o.f."""
+    N, p, K = 300, 3, 120
+    Xs, Y, _, _ = simulate_sur(N_tr=N, N_te=5, K=K, p=p, k=3, seed=11)
+    est = ALSGLS(rank=3, max_sweeps=6).fit(Xs, Y)
+    p_total = sum(est.n_features_in_)
+    assert p_total > est.n_obs_, "test setup must have p_total > N"
+    expected_df = est.n_obs_ * est.n_targets_ - p_total
+
+    band = est.predict_interval(Xs, alpha=0.05, return_type="confidence")
+    half = (band["upper"] - band["lower"]) / 2.0
+    se = np.sqrt(
+        np.maximum(
+            compute_prediction_variance(
+                Xs, est.F_, est.D_, est.cov_params_, include_residual=False
+            ),
+            0.0,
+        )
+    )
+    np.testing.assert_allclose(half / se, stats.t.ppf(0.975, expected_df), rtol=1e-8)

--- a/tests/test_audit_regressions.py
+++ b/tests/test_audit_regressions.py
@@ -130,15 +130,18 @@ class TestFStepLineSearch:
         + K log s, so an unpenalised solver run on ``sY`` must trace the
         rescaled iterates of the run on ``Y``.  (The ridge terms are absolute
         and therefore scale-dependent by construction, which is why this is
-        asserted at lam=0; ``d_floor`` is a variance floor and is matched to
-        the scale for the same reason.)
+        asserted at lam=0.)
+
+        ``d_floor`` used to be an absolute variance and had to be scaled by
+        s**2 here to compensate.  It is now taken relative to the residual
+        variance, so the caller no longer scales it -- passing a scaled value
+        would floor the fit twice over.  ``scale_floor`` bounds a ratio of
+        quadratic forms, which is already scale free, so it is left alone.
         """
         Xs, Y, _, _ = simulate_sur(N_tr=120, N_te=10, K=8, p=3, k=2, seed=1)
         kw = {"k": 2, "sweeps": 30, "lam_F": 0.0, "lam_B": 0.0}
         B1, F1, D1, _, _ = als_gls(Xs, Y, **kw)
-        _, _, _, _, infos = als_gls(
-            Xs, s * Y, d_floor=1e-8 * s * s, scale_floor=1e-8 * s * s, **kw
-        )
+        _, _, _, _, infos = als_gls(Xs, s * Y, **kw)
 
         R = s * Y - XB_from_Blist(Xs, [s * b for b in B1])
         ref = float(nll_per_row(R, s * F1, s * s * D1))
@@ -251,3 +254,47 @@ def test_zero_ridge_on_a_singular_design_explains_itself():
 
     # A positive ridge still solves it.
     als_gls([x, x], y, k=1, lam_B=1e-3, lam_F=1e-3, sweeps=1)
+
+
+class TestVarianceFloorIsRelative:
+    """``d_floor`` is a variance, so an absolute value is not scale-equivariant.
+
+    Under ``Y -> sY`` the true ``D`` scales as ``s**2``, so a fixed floor of
+    1e-8 swallows the whole covariance once ``s`` is small: every entry lands
+    on the floor and the fit stops tracking the data.  Measured on ``B``, which
+    must satisfy ``B(sY) == B(Y)`` exactly, the error saturated at 2.6e-2 for
+    every ``s <= 1e-4``.
+
+    Taken relative to the residual variance scale it transforms correctly, and
+    ``d_floor`` keeps a meaning the caller can reason about: "no variance below
+    this fraction of a typical one".
+
+    Known bound: below roughly ``s = 1e-6`` other absolute constants take over
+    -- ``clip(D, 1e-12)`` in ops.py, the ``1e-8`` floors on the SVD threshold
+    and the preconditioner in als.py -- and equivariance degrades again.
+    Making those relative means threading a scale reference through the
+    numerical core, which is not attempted here.
+    """
+
+    def test_fit_is_scale_invariant_over_the_practical_range(self):
+        import numpy as np
+
+        from alsgls import ALSGLS
+
+        rng = np.random.RandomState(7)
+        n, n_eq, p = 120, 5, 3
+        xs = [rng.randn(n, p) for _ in range(n_eq)]
+        beta = rng.randn(p, n_eq)
+        y = np.column_stack([xs[k] @ beta[:, k] for k in range(n_eq)])
+        y = y + 0.4 * rng.randn(n, n_eq)
+
+        def fit_at(scale):
+            m = ALSGLS(rank=2, cv_random_state=0)
+            m.fit(xs, y * scale)
+            return np.concatenate([np.ravel(b) for b in m.B_list_]) / scale
+
+        base = fit_at(1.0)
+        for scale in (1e-2, 1e-4):
+            assert np.max(np.abs(fit_at(scale) - base)) < 1e-3, (
+                f"B is not invariant at s={scale}"
+            )


### PR DESCRIPTION
Three defects, each producing a plausible but wrong number. Each fix ships with a test
confirmed to fail without it.

## 1. Every reported 95% interval was 6.48x too wide

`api.py` computed residual degrees of freedom as `nobs - p_total`: a per-equation row count
minus the system-wide parameter count. Those are two different sample sizes.
`linearmodels.system.SUR`, checked directly, reports `nobs = N*K` and
`df_resid = N*K - p_total`.

At the README's own benchmark point (N=300, p=3, K=120) the old expression goes negative and
clamps to **df = 1**, so the t critical value is 12.71 instead of 1.96. Measured mean 95% CI
width across all coefficients:

```
before   0.725908
after    0.111977      ratio 6.48x
```

`df_resid` is now `N*K - p*K` = 35,640 at that point, and the t critical value is 1.9600.
Affects `pvalues`, `conf_int`, `get_prediction` and `ALSGLS.predict_interval`.

## 2. `lam_F=0` and `lam_B=0` were silently replaced by 1e-3

`_validation.py:209` read `float(lam_F or 1e-3)`. `0.0` is falsy in Python, so a requested
zero ridge became the default — on the line immediately after the validation above it
explicitly accepts 0 as "non-negative".

Fits requested with `lam=0` were **bit-identical** to the default:

```
max |B(lam=0) - B(lam=1e-3)|   0.000e+00     before
max |F(lam=0) - F(lam=1e-3)|   0.000e+00     before
                               2.464e-05     after (B)
                               1.007e-03     after (F)
```

The ridge could not be turned off. At data scale s=100, 99.7% of the F-gradient norm is this
un-disableable term. This also turned out to be the real cause of a residual scale
non-equivariance: with the ridge genuinely at zero, equivariance holds to 7e-8. (Two other
hypotheses — an absolute `d_floor`, then the ridge magnitude — were chased and killed first.)

## 3. The F-step line search could never run

The initial trial step was hard-coded to 1 for the raw direction `F - grad_F`, but
`||grad_F||` scales as the inverse data variance. At Fama-French scale — which
`examples/real_data_fama_french.py` produces by dividing returns by 100 — all five ladder
entries `(1, .5, .25, .125, .0625)` overshoot, `accept_t` stays identically `[0.0, 0.0]`, and
F is returned frozen at its PCA initialisation.

That is **5.24 nats/row** worse than one further backtracked step (t=1e-5), with a relative
gradient norm of 4.2e2. It contradicts `docs/source/formal_methods.md` Theorems 1-2, which
state a backtracking line search converging to a stationary point.

## Checks that came out clean

Recorded because they were suspected and are not defects: `compute_XtSigmaInvX` matches a
dense Kronecker reference to 1e-15; `WoodburyWeight` satisfies `W'W - Sigma^-1` = 1.1e-15
with an exact adjoint; `solve_gls_weighted` (LSMR) matches dense GLS to 2e-11; and
`grad_F_nll`, `siginv_diag`, `nll_per_row`, the `c*` scale correction, the BIC formula,
`_auto_rank`, CV reproducibility, determinism and row-order invariance all verified correct.

## Not filed

Two marginal findings, deliberately left: the README describes the stopping rule as a
"relative drop in NLL" while the code divides by `max(1.0, |nll|)`, which is absolute when
`|nll| < 1` — real but negligible; and `select_rank_bic`'s doc bullets do not mention the
`+k` term although the code matches the stated formula exactly.

## Tests

89 -> **106 passed**, 0 failed. Reverting all three fixes while keeping
`tests/test_audit_regressions.py` gives 13 failing assertions.

Note: `mypy` fails in a clean venv on pre-existing issues (missing scipy stubs, numpy `.pyi`
under Python 3.14), unrelated to this branch.
