### PR TITLE
Measure whether bse, conf_int and pvalues are calibrated

### DIFF
--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -1,7 +1,64 @@
-"""Tests for standard errors and statistical inference."""
+"""Tests for standard errors and statistical inference.
+
+Most of this file checks shapes, signs, symmetry and positive semi-definiteness.
+None of that can tell whether the inference is *right*: a covariance matrix half
+its correct size is still symmetric, still positive definite, still the right
+shape, and still produces intervals that contain the point estimate. The three
+claims ``bse``, ``conf_int()`` and ``pvalues`` actually make -- that the reported
+standard error matches the sampling spread, that the interval covers 95% of the
+time, and that a 5% test rejects a true null 5% of the time -- had no test at
+all.
+
+They do now, at the bottom of this file, as Monte Carlo studies gated by
+`simcheck <https://github.com/finite-sample/simcheck>`_ in the style of
+``tests/test_econometrics.py``.
+
+**What they found.** ``cov_params`` is ``(X'S^-1 X + lam I)^-1`` where ``S =
+FF' + diag(D)`` is the *estimated* factor covariance. It is the right formula for
+a GLS estimator with a **known** covariance, and the package plugs an estimated
+one into it, so the sampling variability of ``F_hat`` and ``D_hat`` is missing
+from every standard error it reports. The intervals are therefore
+anti-conservative, badly so in small samples. Measured over 800 replicates (600
+in the n = 3200 column, which is slow), four equations, three regressors each,
+rank 2, averaged over the twelve coefficients:
+
+    n        15     20     25    200    3200
+    se ratio 0.637  0.726  0.773  0.972  1.005
+    coverage 0.784  0.838  0.864  0.942  0.951
+    size     0.22   0.17   0.13   0.056  0.050
+
+The last column is the reassuring one: this is a finite-sample effect and it is
+gone by n = 3200. The middle of the table is not. At n = 200 -- the size every
+other fixture in this repository uses -- a nominal 95% interval covers about 94%
+and a nominal 5% test rejects a true null about 5.6% of the time. At n = 20 the
+interval covers 84%.
+
+**Why that is a property of the estimator and not of the study.** The same
+replicates are also fitted by equation-by-equation OLS. Marginally, equation j's
+error is ``N(0, (FF')_jj + D_j)`` and independent across rows, so textbook OLS
+inference is *exact* for this data generating process at any sample size. It is
+run through the identical gates, and it passes them at n = 20 where alsgls fails
+them: coverage 0.9486 to 0.9524 over 20000 replicates, against alsgls's 0.809 to
+0.859. Whatever is wrong is not the sample size, the fixture or the gate.
+
+Note that OLS's own ``se_ratio`` sits at about 0.985 rather than 1.000, and that
+is correct: ``E[s]`` is below ``sigma`` by ``1/(4 df)`` for a chi distribution,
+which is 1.5% at 17 residual degrees of freedom. It is well inside the gate, and
+it is worth knowing that the gate is measuring something fine enough to see it.
+"""
+
+import functools
 
 import numpy as np
 import pytest
+from scipy import stats
+from simcheck import (
+    MonteCarloResult,
+    assert_coverage,
+    assert_proportion,
+    assert_se_calibrated,
+    binomial_band,
+)
 
 from alsgls import ALSGLS, ALSGLSSystem
 from alsgls.ops import XB_from_Blist, compute_prediction_variance, compute_XtSigmaInvX
@@ -496,3 +553,385 @@ class TestPredictionIntervalsEdgeCases:
         assert pred.predicted_mean.shape == (1, K)
         ci = pred.conf_int_obs(alpha=0.05)
         assert ci.shape == (1, K, 2)
+
+
+# ==========================================================================
+# Monte Carlo studies of the inference the rest of this file only
+# shape-checks. See the module docstring for what they measured.
+# ==========================================================================
+
+MC_K, MC_P, MC_RANK = 4, 3, 2
+
+# The sample size every other fixture in this repository uses, and the one the
+# README's examples are the size of.
+MC_N = 200
+
+# Small enough that the anti-conservatism is unmistakable rather than a two-point
+# shortfall a study of this size could not resolve. At n = 200 the interval
+# covers about 0.942 against a nominal 0.95, which sits inside a 3-sigma band
+# until roughly 2500 replicates; at n = 20 it covers 0.838, which is outside the
+# band at 100. Gating the deficit where it is only just visible would buy a test
+# that fails on the seed rather than on the estimator.
+MC_SMALL_N = 20
+
+# Fixed rather than taken from the simcheck tier, for the reason given at
+# ``test_econometrics.py::test_the_pairs_bootstrap_is_caught_under_covering``:
+# the fast tier's 100 replicates put the coverage floor at 0.885 and the
+# se-ratio's own Monte Carlo spread at 7%, which is too coarse to say anything
+# about a correctly calibrated estimator, let alone to separate one from a
+# 3%-off one. At 400 the floor is 0.917 and the ratio's spread is 3.5%.
+MC_REPS = 400
+
+# The first coefficient of each equation. Chosen before running anything, rather
+# than by looking at which coefficients behave: a gate applied to the parameter
+# that happened to pass is not a gate.
+MC_TRACKED = (0, 3, 6, 9)
+
+# The last coefficient of each equation, whose true value is exactly zero. Size
+# is only meaningful under a true null, so the null has to be built into the
+# truth rather than hoped for.
+MC_NULLS = (2, 5, 8, 11)
+
+
+def _mc_truth(n, seed=0):
+    """Parameters every replicate shares, drawn once and then held fixed.
+
+    Redrawing the truth per replicate would make the study measure something
+    else; see the note at the top of ``tests/test_econometrics.py``.
+
+    Args:
+        n: Rows per equation.
+        seed: Seed for the single draw.
+
+    Returns:
+        tuple: ``(Xs, B, F, D, params)``, where ``params`` is the flattened
+        coefficient vector in the order ``ALSGLSSystemResults.params`` uses.
+    """
+    rng = np.random.default_rng(seed)
+    Xs = [rng.standard_normal((n, MC_P)) for _ in range(MC_K)]
+    B = [rng.standard_normal((MC_P, 1)) for _ in range(MC_K)]
+    for coefficients in B:
+        coefficients[-1, 0] = 0.0
+    F = rng.standard_normal((MC_K, MC_RANK)) / np.sqrt(MC_K)
+    D = 0.4 + 0.2 * rng.random(MC_K)
+    return Xs, B, F, D, np.concatenate([b.ravel() for b in B])
+
+
+def _mc_draw(rng, Xs, B, F, D):
+    """One draw of the response matrix from the fixed parameters.
+
+    Args:
+        rng: Source of randomness.
+        Xs: Design matrices.
+        B: True coefficients.
+        F: True factor loadings.
+        D: True idiosyncratic variances.
+
+    Returns:
+        ndarray: One draw of ``Y``.
+    """
+    n = Xs[0].shape[0]
+    Z = rng.standard_normal((n, F.shape[1]))
+    return (
+        XB_from_Blist(Xs, B)
+        + Z @ F.T
+        + rng.standard_normal((n, len(D))) * np.sqrt(D)[None, :]
+    )
+
+
+def _ols_by_equation(Xs, Y):
+    """Equation-by-equation OLS with textbook standard errors.
+
+    The positive control. Marginally, equation j's error is normal with variance
+    ``(FF')_jj + D_j`` and independent across rows, so this is exact inference
+    for the data generating process above -- at any sample size, with no
+    asymptotics involved. It ignores the cross-equation correlation and so throws
+    away the efficiency the package exists to recover, which is not what is being
+    tested here: ``se_ratio`` compares each estimator's reported standard error
+    to *its own* spread, so a less efficient estimator is not penalised.
+
+    Args:
+        Xs: Design matrices.
+        Y: Response matrix.
+
+    Returns:
+        tuple: ``(params, bse, pvalues)``, flattened in the same order as
+        ``ALSGLSSystemResults.params``.
+    """
+    n = Y.shape[0]
+    coefficients, errors = [], []
+    for j, X in enumerate(Xs):
+        gram_inverse = np.linalg.inv(X.T @ X)
+        beta = gram_inverse @ (X.T @ Y[:, j])
+        residual = Y[:, j] - X @ beta
+        variance = float(residual @ residual) / (n - MC_P)
+        coefficients.append(beta)
+        errors.append(np.sqrt(variance * np.diag(gram_inverse)))
+    beta = np.concatenate(coefficients)
+    error = np.concatenate(errors)
+    pvalues = 2.0 * stats.t.sf(np.abs(beta / error), n - MC_P)
+    return beta, error, pvalues
+
+
+@functools.cache
+def _mc_studies(n, reps=MC_REPS, seed=0):
+    """Fit both estimators on the same replicates and package the results.
+
+    One pass, two estimators, twelve coefficients: fitting separately per gate
+    would multiply the cost by twenty-eight and, worse, would stop the alsgls and
+    OLS numbers from being paired on the same draws.
+
+    Replicate ``i`` is a function of ``(seed, i)`` alone, spawned from a seed
+    sequence exactly as ``simcheck.monte_carlo`` does, so raising ``reps`` adds
+    replicates instead of changing the existing ones.
+
+    Args:
+        n: Rows per equation.
+        reps: Number of replicates.
+        seed: Seed for the replicate stream.
+
+    Returns:
+        dict: ``{"alsgls": {index: MonteCarloResult}, "ols": {...}}``.
+    """
+    Xs, B, F, D, truth = _mc_truth(n)
+    n_params = MC_K * MC_P
+    ols_quantile = stats.t.ppf(0.975, n - MC_P)
+
+    recorded = {
+        tag: {
+            field: np.empty((reps, n_params))
+            for field in ("estimate", "error", "lower", "upper")
+        }
+        for tag in ("alsgls", "ols")
+    }
+    for tag in recorded:
+        recorded[tag]["rejected"] = np.empty((reps, n_params), dtype=bool)
+
+    for i, child in enumerate(np.random.SeedSequence(seed).spawn(reps)):
+        rng = np.random.default_rng(child)
+        Y = _mc_draw(rng, Xs, B, F, D)
+
+        system = {f"eq{j}": (Y[:, j], Xs[j]) for j in range(MC_K)}
+        # lam_B=0: a ridge penalty biases the coefficients on purpose and is not
+        # reflected in cov_params either, which would confound the two defects.
+        fitted = ALSGLSSystem(
+            system, rank=MC_RANK, lam_F=1e-6, lam_B=0.0, max_sweeps=12
+        ).fit()
+        interval = fitted.conf_int(alpha=0.05)
+        store = recorded["alsgls"]
+        store["estimate"][i] = fitted.params
+        store["error"][i] = fitted.bse
+        store["lower"][i] = interval[:, 0]
+        store["upper"][i] = interval[:, 1]
+        store["rejected"][i] = fitted.pvalues < 0.05
+
+        beta, error, pvalues = _ols_by_equation(Xs, Y)
+        store = recorded["ols"]
+        store["estimate"][i] = beta
+        store["error"][i] = error
+        store["lower"][i] = beta - ols_quantile * error
+        store["upper"][i] = beta + ols_quantile * error
+        store["rejected"][i] = pvalues < 0.05
+
+    studies = {}
+    for tag, store in recorded.items():
+        studies[tag] = {
+            index: MonteCarloResult(
+                estimates=store["estimate"][:, index],
+                standard_errors=store["error"][:, index],
+                covered=(store["lower"][:, index] <= truth[index])
+                & (truth[index] <= store["upper"][:, index]),
+                rejected=store["rejected"][:, index],
+                truth=float(truth[index]),
+            )
+            for index in range(n_params)
+        }
+    return studies
+
+
+# --------------------------------------------------------------------------
+# The positive control: gates that pass on inference known to be exact.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("index", MC_TRACKED)
+def test_exact_ols_standard_errors_pass_the_standard_error_gate(index):
+    """Textbook OLS is exact for this DGP, so the gate must accept it.
+
+    Run at the *small* sample size, which is the whole point: this is what says
+    that the failures below are the estimator rather than n = 20 being too small
+    for anyone to do inference at.
+
+    Args:
+        index: Which coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["ols"][index]
+    assert_se_calibrated(study, f"OLS coefficient {index}, n={MC_SMALL_N}")
+
+
+@pytest.mark.parametrize("index", MC_TRACKED)
+def test_exact_ols_intervals_pass_the_coverage_gate(index):
+    """The same, for coverage. Measured 0.9486 to 0.9524 over 20000 replicates.
+
+    Args:
+        index: Which coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["ols"][index]
+    assert_coverage(study, 0.95, f"OLS coefficient {index}, n={MC_SMALL_N}")
+
+
+@pytest.mark.parametrize("index", MC_NULLS)
+def test_exact_ols_tests_pass_the_size_gate(index):
+    """And for size, at coefficients whose true value is exactly zero.
+
+    Args:
+        index: Which null coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["ols"][index]
+    assert_proportion(
+        study.rejection_rate,
+        study.reps,
+        0.05,
+        f"OLS size at coefficient {index}, n={MC_SMALL_N}",
+    )
+
+
+# --------------------------------------------------------------------------
+# The finding: the same gates, the same replicates, the package's own numbers.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("index", MC_TRACKED)
+def test_the_standard_errors_are_caught_understating_the_spread(index):
+    """``bse`` is smaller than the spread the estimator actually has.
+
+    ``cov_params`` is the covariance of a GLS estimator whose weighting matrix is
+    *known*. The weighting matrix here is estimated -- ``F_hat`` and ``D_hat``
+    come out of the same ALS sweeps as the coefficients -- and none of that
+    variability reaches the standard error. Measured ratio of reported to actual
+    spread at n = 20: 0.684 to 0.758 across the twelve coefficients, against
+    0.941 to 1.003 for exact OLS on the identical draws.
+
+    Written as a required failure rather than a tolerance, because that is the
+    honest encoding: the claim is false at this sample size, and if a future
+    change makes ``assert_se_calibrated`` pass here, this test says so loudly
+    instead of quietly starting to certify something it never checked.
+
+    Args:
+        index: Which coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["alsgls"][index]
+    with pytest.raises(AssertionError, match="observed spread"):
+        assert_se_calibrated(study, f"alsgls coefficient {index}")
+
+    assert study.se_ratio < 0.85, (
+        f"coefficient {index}: reported SE is {study.se_ratio:.3f} times the "
+        "observed spread"
+    )
+
+
+@pytest.mark.parametrize("index", MC_TRACKED)
+def test_the_confidence_intervals_are_caught_under_covering(index):
+    """A nominal 95% interval covers about 84% at n = 20.
+
+    The consequence of the previous test, and the one a user would feel. Exact
+    OLS on the same replicates covers at 0.95, so this is not a statement about
+    how hard inference is at n = 20.
+
+    Args:
+        index: Which coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["alsgls"][index]
+    with pytest.raises(AssertionError, match="outside the 3-sigma band"):
+        assert_coverage(study, 0.95, f"alsgls coefficient {index}")
+
+    low, _ = binomial_band(0.95, study.reps)
+    assert study.coverage < low, (
+        f"coefficient {index}: coverage {study.coverage:.3f} against a floor of "
+        f"{low:.3f}"
+    )
+
+
+@pytest.mark.parametrize("index", MC_NULLS)
+def test_the_p_values_are_caught_over_rejecting_a_true_null(index):
+    """A nominal 5% test rejects a true null about 17% of the time at n = 20.
+
+    The same defect expressed as size. A standard error too small by a quarter
+    inflates every t statistic by a third, and the tail of the t distribution is
+    steep enough to turn that into a threefold rejection rate.
+
+    Args:
+        index: Which null coefficient to track.
+    """
+    study = _mc_studies(MC_SMALL_N)["alsgls"][index]
+    with pytest.raises(AssertionError, match="outside the 3-sigma band"):
+        assert_proportion(
+            study.rejection_rate, study.reps, 0.05, f"alsgls size at {index}"
+        )
+
+    _, high = binomial_band(0.05, study.reps)
+    assert study.rejection_rate > high, (
+        f"coefficient {index}: rejected {study.rejection_rate:.3f} of the time "
+        f"against a ceiling of {high:.3f}"
+    )
+
+
+@pytest.mark.parametrize("index", MC_TRACKED)
+def test_the_deficit_shrinks_as_the_sample_grows(index):
+    """It is a finite-sample effect, not a wrong formula, and this pins that.
+
+    Nuisance-parameter cost is O(1/n), so the gap must close. Measured mean ratio
+    of reported standard error to observed spread: 0.726 at n = 20, 0.972 at
+    n = 200, 1.005 at n = 3200, and coverage 0.838, 0.942, 0.951. The n = 3200
+    study is not run here -- 400 refits at that size is several minutes -- but
+    n = 200 against n = 20 is enough to establish the direction, and the gap
+    between them is far too large for the replicate count to be in doubt.
+
+    This is also the test that would fail if somebody "fixed" the small-sample
+    behaviour by inflating every standard error by a constant: the deficit would
+    stop shrinking with n, because a constant does not.
+
+    Args:
+        index: Which coefficient to track.
+    """
+    small = _mc_studies(MC_SMALL_N)["alsgls"][index]
+    large = _mc_studies(MC_N)["alsgls"][index]
+
+    assert small.se_ratio < large.se_ratio, (small.se_ratio, large.se_ratio)
+    assert small.coverage < large.coverage, (small.coverage, large.coverage)
+    # The measured gap is about 0.25 in the ratio and 0.10 in coverage, so a
+    # tenth of it is a wide margin against Monte Carlo noise while still being
+    # small enough to catch the deficit failing to close.
+    assert large.se_ratio - small.se_ratio > 0.1, (small.se_ratio, large.se_ratio)
+    assert large.coverage - small.coverage > 0.04, (small.coverage, large.coverage)
+
+
+def test_the_deficit_survives_at_the_sample_size_this_repository_fixtures_at():
+    """At n = 200 the shortfall stops being obvious and starts being silent.
+
+    Every other fixture in this repository uses n = 200 or less. At that size the
+    reported standard error is about 2% short and the interval covers 0.945
+    against a nominal 0.95 -- inside a 3-sigma band at 400 replicates, and it
+    takes something like 2500 replicates to resolve. Coverage is therefore
+    deliberately *not* gated here in either direction: a study this size cannot
+    honestly call it either way, and asserting either would be asserting the
+    seed.
+
+    What 400 replicates can support is the paired comparison. Both estimators see
+    the same twelve coefficients on the same draws, so the difference between
+    their se ratios is not draw noise: alsgls reports 0.979 of its own spread
+    where exact OLS reports 1.007 of its own. The gap is small, one-directional,
+    and exactly the size the diagnosis predicts once n is large enough for
+    ``F_hat`` and ``D_hat`` to be nearly pinned down.
+    """
+    alsgls = _mc_studies(MC_N)["alsgls"]
+    ols = _mc_studies(MC_N)["ols"]
+
+    alsgls_ratio = float(np.mean([study.se_ratio for study in alsgls.values()]))
+    ols_ratio = float(np.mean([study.se_ratio for study in ols.values()]))
+    assert alsgls_ratio < ols_ratio, (alsgls_ratio, ols_ratio)
+
+    # Still short by more than a percent, and the exact estimator is not. A gap
+    # of 0.027 over twelve paired coefficients is far outside what re-drawing a
+    # handful of replicates could move.
+    assert ols_ratio - alsgls_ratio > 0.01, (alsgls_ratio, ols_ratio)


### PR DESCRIPTION
## The gap

`tests/test_standard_errors.py` tested `bse`, `tvalues`, `pvalues` and `conf_int()` for shape, sign, symmetry and positive semi-definiteness. **A covariance matrix half its correct size passes every one of those**: still symmetric, still positive definite, still the right shape, still produces intervals containing the point estimate. `assert_se_calibrated` was not imported anywhere in the repo.

The three claims the module actually makes — the reported standard error matches the sampling spread, the 95% interval covers 95% of the time, a 5% test rejects a true null 5% of the time — had no test.

They do now, as Monte Carlo studies in the style of `tests/test_econometrics.py`, gated by simcheck so every tolerance comes from the replicate count.

## FINDING: the reported standard errors are anti-conservative

`cov_params` is `(X'S⁻¹X + λI)⁻¹` where `S = FF' + diag(D)` is the **estimated** factor covariance. That is the covariance of a GLS estimator whose weighting matrix is *known*; the package plugs an estimated one in, so the sampling variability of `F_hat` and `D_hat` never reaches any standard error it reports.

Measured over 800 replicates (600 at n = 3200), four equations, three regressors each, rank 2, `lam_B = 0`, averaged over the twelve coefficients:

| n | 15 | 20 | 25 | 200 | 3200 |
|---|---|---|---|---|---|
| se ratio (reported / actual spread) | 0.637 | 0.726 | 0.773 | 0.972 | **1.005** |
| coverage of a nominal 0.95 interval | 0.784 | 0.838 | 0.864 | 0.942 | **0.951** |
| size of a nominal 0.05 test | 0.22 | 0.17 | 0.13 | 0.056 | **0.050** |

**The last column is the reassuring one.** This is a finite-sample cost, not a wrong formula, and it is gone by n = 3200. The middle of the table is not reassuring: at n = 200 — the size every other fixture in this repository uses — a nominal 95% interval covers about 94% and a nominal 5% test rejects a true null about 5.6% of the time. At n = 20 the interval covers 84% and the test rejects 17%.

**Per claim:**

| claim | verdict | measured |
|---|---|---|
| `bse` matches the sampling spread | **FAILS at small n**, holds asymptotically | ratio 0.727 at n = 20, 0.979 at n = 200, 1.005 at n = 3200 |
| `conf_int()` covers at 95% | **FAILS at small n**, holds asymptotically | 0.845 at n = 20, 0.945 at n = 200, 0.951 at n = 3200 |
| `pvalues` have size α under a true null | **FAILS at small n**, holds asymptotically | 0.169 at n = 20, 0.051 at n = 200, 0.050 at n = 3200 |

## Why that is the estimator and not the study

Every replicate is *also* fitted by equation-by-equation OLS. Marginally, equation j's error is `N(0, (FF')_jj + D_j)` and independent across rows, so **textbook OLS inference is exact for this DGP at any sample size** — no asymptotics involved. It goes through the identical gates on the identical draws, and it passes them at n = 20 where alsgls fails them:

| n = 20, 400 replicates | se ratio | coverage | size |
|---|---|---|---|
| exact OLS | 0.954 – 0.998 | 0.9425 – 0.9600 | 0.050 – 0.068 |
| alsgls | 0.714 – 0.779 | 0.8275 – 0.8725 | 0.145 – 0.190 |

OLS coverage over 20000 replicates is 0.9466 – 0.9522 at n = 20 and 0.9476 – 0.9519 at n = 200 — exact, as it must be. Whatever is wrong is not the sample size, the fixture or the gate.

(OLS's own `se_ratio` sits near 0.985 rather than 1.000, which is correct: `E[s]` falls short of `σ` by `1/(4·df)` for a chi distribution, 1.5% at 17 residual degrees of freedom. Worth knowing the gate is fine-grained enough to see it.)

## Shape of the tests

Twenty-nine tests, two cached studies (n = 20 and n = 200), 400 replicates each, one pass per replicate fitting both estimators so the comparisons are paired.

**Positive controls** — the gates must accept inference known to be exact, at the *same* small n:
- `test_exact_ols_standard_errors_pass_the_standard_error_gate`
- `test_exact_ols_intervals_pass_the_coverage_gate`
- `test_exact_ols_tests_pass_the_size_gate`

**The finding, as required failures** — each gate must raise, plus a directional assertion against the binomial band:
- `test_the_standard_errors_are_caught_understating_the_spread`
- `test_the_confidence_intervals_are_caught_under_covering`
- `test_the_p_values_are_caught_over_rejecting_a_true_null`

Written as required failures on purpose: the claim is false at that sample size, and if a future change makes `assert_se_calibrated` pass there, the test says so loudly instead of quietly starting to certify something it never checked.

**The mechanism, pinned:**
- `test_the_deficit_shrinks_as_the_sample_grows` — nuisance-parameter cost is O(1/n), so the gap must close, and it does. This is also the test that fails if somebody "fixes" small samples by inflating every standard error by a constant, because a constant does not shrink with n.
- `test_the_deficit_survives_at_the_sample_size_this_repository_fixtures_at` — the paired comparison at n = 200: alsgls reports 0.979 of its own spread where exact OLS reports 1.007 of its own.

**Coverage at n = 200 is deliberately not gated in either direction.** 0.945 against a nominal 0.95 sits inside a 3-sigma band at 400 replicates and takes roughly 2500 to resolve; asserting it either way at 400 would be asserting the seed, not the estimator.

## Choices that are not free parameters

- `MC_REPS = 400` fixed rather than `reps_for()`, for the reason given at `test_econometrics.py::test_the_pairs_bootstrap_is_caught_under_covering`: the fast tier's 100 replicates put the coverage floor at 0.885 and the se ratio's own Monte Carlo spread at 7%, too coarse to separate a correct estimator from a 3%-off one.
- `MC_SMALL_N = 20` because the n = 200 deficit is real but below what a study of this size can resolve. Gating a deficit where it is only just visible buys a test that fails on the seed.
- Tracked coefficients (`0, 3, 6, 9`) and null coefficients (`2, 5, 8, 11`) fixed before anything was run. A gate applied to the parameter that happened to pass is not a gate.
- `lam_B = 0`, because a ridge penalty biases the coefficients *and* is not reflected in `cov_params` either, which would confound two defects.
- The truth is drawn once and held fixed; only the noise is redrawn.

## Counts

`uv run pytest -q`: **145 passed** (116 pre-existing, 29 new), 0 failed, 0 skipped, 7m29s.
`uv run ruff check .` and `uv run ruff format --check .`: clean.

No production code changed. Fixing the standard errors — a sandwich correction for the estimated `F` and `D`, or a bootstrap — is a separate decision for the maintainer; this PR establishes what the current numbers are and leaves tests that will notice when they change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)