### PR TITLE
Cite the version this package actually is

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
     given-names: "Gaurav"
     email: "contact@gsood.com"
 title: "alsgls: Lightweight low-rank+diag GLS/SUR via ALS with EM baseline"
-version: 0.1.0
+version: 1.2.0
 date-released: 2024-01-01
 url: "https://github.com/finite-sample/alsgls"
 repository-code: "https://github.com/finite-sample/alsgls"


### PR DESCRIPTION
`CITATION.cff` recorded version `0.1.0`; `project.version` is `1.2.0`. Whoever cites this package copies that number, so a stale one outlives the release in someone else's bibliography.

`date-released` is deliberately **unchanged** here. No tag names `1.2.0` in this repo, so there is no release date to be confident about and inventing one would be worse than leaving the old value visible.

That is worth a separate look on its own: `project.version` says 1.2.0 and nothing has ever been tagged.

Found by `preen check` sweeping the fleet — this repo was one of eight — and applied with `preen fix citation`, which also moves `date-released` to the date of the tag naming the release rather than leaving a right version beside a wrong date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011SkMDqnEFUgr7Mbc1HwMqX