### PR TITLE
Configure pytest to fail on what it should fail on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ ignore-words-list = "als"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+minversion = "6"
+log_level = "INFO"
+xfail_strict = true
+filterwarnings = ["error"]
+addopts = ["--strict-config", "--strict-markers", "-ra"]
 
 [tool.coverage.run]
 source = ["src"]

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -593,7 +593,7 @@ MC_TRACKED = (0, 3, 6, 9)
 MC_NULLS = (2, 5, 8, 11)
 
 
-def _mc_truth(n, seed=0):
+def _mc_truth(n, truth_seed=0):
     """Parameters every replicate shares, drawn once and then held fixed.
 
     Redrawing the truth per replicate would make the study measure something
@@ -601,13 +601,15 @@ def _mc_truth(n, seed=0):
 
     Args:
         n: Rows per equation.
-        seed: Seed for the single draw.
+        truth_seed: Seed for the single draw. Named apart from the replicate
+            seed on purpose -- they are different quantities, and sharing the
+            name invites threading one into the other.
 
     Returns:
         tuple: ``(Xs, B, F, D, params)``, where ``params`` is the flattened
         coefficient vector in the order ``ALSGLSSystemResults.params`` uses.
     """
-    rng = np.random.default_rng(seed)
+    rng = np.random.default_rng(truth_seed)
     Xs = [rng.standard_normal((n, MC_P)) for _ in range(MC_K)]
     B = [rng.standard_normal((MC_P, 1)) for _ in range(MC_K)]
     for coefficients in B:


### PR DESCRIPTION
py-canon 1.3.0 puts the whole sp-repo-review PP301–PP309 set in the template, and preen's `pytest-config` check now gates on it.

```toml
minversion, log_level, xfail_strict, filterwarnings = ["error"]
addopts: -ra, --strict-config, --strict-markers
```

These decide whether a run **fails**, not how it reads. Without `filterwarnings` a dependency's DeprecationWarning stays invisible until the release that removes the API; without `--strict-markers` a typo in a marker name selects nothing and reports success; without `--strict-config` a typo in this very table is ignored.

Applied with `preen fix pytest-config`. **The suite was run under the new settings before this was opened** — the whole point is that warnings now fail, so a config that quietly breaks the suite would defeat the purpose. Anything that needed a scoped ignore or a real fix got one, and is described above if so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)